### PR TITLE
fix: incorrect AWS credentials extracfg field name

### DIFF
--- a/extracfg.txt
+++ b/extracfg.txt
@@ -5,4 +5,4 @@
 # awsProfile=default
 
 # set aws credential file path
-# awsCredsFile=~/.aws/credentials
+# awsCredentialFile=~/.aws/credentials


### PR DESCRIPTION
Fixes the example extracfg.txt file which had an incorrect field name for the AWS credentials file