### PR TITLE
fix: credentials refresh in awsemfexporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/aws-observability/aws-otel-collector
 
-go 1.22.0
+go 1.22.4
 
-toolchain go1.22.2
+toolchain go1.23.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.6
@@ -181,6 +181,7 @@ require (
 	github.com/Showmax/go-fqdn v1.0.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.1 // indirect
 	github.com/alecthomas/units v0.0.0-20240626203959-61d1e3462e30 // indirect
+	github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws v0.0.0-20250116001040-07637c7e4577 // indirect
 	github.com/antchfx/xmlquery v1.4.2 // indirect
 	github.com/antchfx/xpath v1.3.2 // indirect
 	github.com/apache/thrift v0.21.0 // indirect
@@ -553,3 +554,5 @@ exclude github.com/openshift/api v3.9.0+incompatible
 
 // https://groups.google.com/g/golang-announce/c/-nPEi39gI4Q/m/cGVPJCqdAQAJ?pli=1
 exclude golang.org/x/crypto v0.29.0
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.115.0 => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutil v0.0.0-20250116001040-07637c7e4577

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,10 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alecthomas/units v0.0.0-20240626203959-61d1e3462e30 h1:t3eaIm0rUkzbrIewtiFmMK5RXHej2XnoXNhxVsAYUfg=
 github.com/alecthomas/units v0.0.0-20240626203959-61d1e3462e30/go.mod h1:fvzegU4vN3H1qMT+8wDmzjAcDONcgo2/SZ/TyfdUOFs=
+github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutil v0.0.0-20250116001040-07637c7e4577 h1:pgMns0yt20aGMHMMkWKYjtxZkIdSslMrxCzan+v/6Hc=
+github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutil v0.0.0-20250116001040-07637c7e4577/go.mod h1:YL1Y62PxJ7dem1ZBUqCfvbnePaGr5p7DTSyOXSCi6O4=
+github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws v0.0.0-20250116001040-07637c7e4577 h1:yvxUkVwJfYCB7+XXIh9rU37MwNnV4m70NVkoPS6bzRg=
+github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws v0.0.0-20250116001040-07637c7e4577/go.mod h1:t/hYoRTnlPuRjh8y0BwVGgNvNIXpU2QJME5YVppUUHQ=
 github.com/antchfx/xmlquery v1.4.2 h1:MZKd9+wblwxfQ1zd1AdrTsqVaMjMCwow3IqkCSe00KA=
 github.com/antchfx/xmlquery v1.4.2/go.mod h1:QXhvf5ldTuGqhd1SHNvvtlhhdQLks4dD0awIVhXIDTA=
 github.com/antchfx/xpath v1.3.2 h1:LNjzlsSjinu3bQpw9hWMY9ocB80oLOWuQqFvO6xt51U=
@@ -948,8 +952,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.1
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.115.0/go.mod h1:l2Q+MmYk2ZRDSbhX9GlJYvBXC51AqhDJAj2ne290Xik=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.115.0 h1:Jh3XgGs4YBz0zCj6HU49gspyAjJUHf5DVCQTyw69FDw=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.115.0/go.mod h1:biiJzDxPevfbrnGaTZOU2I0f1zT3DWUGkpXdH/+uQ8k=
-github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.115.0 h1:qfUo0NYFcKo3bK63o2FbGBmFWd7iHlXtwOEMgvb5RaM=
-github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.115.0/go.mod h1:CCMkr9ZFAzjSY1SqRqXmpBjcY2qPYzu3dTPS72wBZwU=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.115.0 h1:DceAGbtG1BVqnA9kOsHDIs+o1ER+J51ayyDpu5c+B/M=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.115.0/go.mod h1:4HebVM9TmMpsxZAXLX5om998dTm1JUndjcpmhrnGkx4=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs v0.115.0 h1:e8YcdSlrjt7RE6a9Fk+lNlqei8qv7l0TP/+7RlvDm7o=

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -1,8 +1,8 @@
 module github.com/aws-observability/aws-otel-collector/testbed
 
-go 1.22.0
+go 1.22.4
 
-toolchain go1.22.2
+toolchain go1.23.4
 
 require (
 	github.com/aws-observability/aws-otel-collector v0.42.0

--- a/vendor/github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws/LICENSE
+++ b/vendor/github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws/Makefile
+++ b/vendor/github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/vendor/github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws/credential.go
+++ b/vendor/github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws/credential.go
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package aws // import "github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws"
+import (
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+type credentialsProvider []func(string) credentials.Provider
+type CredentialsChainOverride struct {
+	credentialsProvider credentialsProvider
+}
+
+var credentialsChainOverride *CredentialsChainOverride
+
+func GetCredentialsChainOverride() *CredentialsChainOverride {
+	if credentialsChainOverride == nil {
+		credentialsChainOverride = &CredentialsChainOverride{credentialsProvider: make([]func(string) credentials.Provider, 0)}
+	}
+	return credentialsChainOverride
+}
+
+func (c *CredentialsChainOverride) AppendCredentialsChain(credentialsProvider func(string) credentials.Provider) {
+	c.credentialsProvider = append(c.credentialsProvider, credentialsProvider)
+}
+
+func (c *CredentialsChainOverride) GetCredentialsChain() []func(string) credentials.Provider {
+	return c.credentialsProvider
+}
+
+func init() {
+	GetCredentialsChainOverride()
+}

--- a/vendor/github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws/imdsretryer.go
+++ b/vendor/github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws/imdsretryer.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package aws // import "github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws"
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"go.uber.org/zap"
+)
+
+const (
+	DefaultIMDSRetries = 1
+)
+
+type IMDSRetryer struct {
+	client.DefaultRetryer
+	logger *zap.Logger
+}
+
+// NewIMDSRetryer allows us to retry imds errors
+func NewIMDSRetryer(retryNumber int) IMDSRetryer {
+	imdsRetryer := IMDSRetryer{
+		DefaultRetryer: client.DefaultRetryer{
+			NumMaxRetries: retryNumber,
+		},
+	}
+	logger, err := zap.NewDevelopment()
+	if err == nil {
+		imdsRetryer.logger = logger
+	}
+	return imdsRetryer
+}
+
+func (r IMDSRetryer) ShouldRetry(req *request.Request) bool {
+	// there is no enum of error codes
+	// EC2MetadataError is not retryable by default
+	// Fallback to SDK's built in retry rules
+	shouldRetry := false
+	var awsError awserr.Error
+	if r.DefaultRetryer.ShouldRetry(req) || (errors.As(req.Error, &awsError) && awsError != nil && awsError.Code() == "EC2MetadataError") {
+		shouldRetry = true
+	}
+	if r.logger != nil {
+		r.logger.Debug("imds error : ", zap.Bool("shouldRetry", shouldRetry), zap.Error(req.Error))
+	}
+	return shouldRetry
+}

--- a/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil/awsconfig.go
+++ b/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil/awsconfig.go
@@ -26,6 +26,14 @@ type AWSSessionSettings struct {
 	ResourceARN string `mapstructure:"resource_arn"`
 	// IAM role to upload segments to a different account.
 	RoleARN string `mapstructure:"role_arn"`
+	// Change the default profile for shared creds file
+	Profile string `mapstructure:"profile"`
+	// Change the default shared creds file location
+	SharedCredentialsFile []string `mapstructure:"shared_credentials_file"`
+	// Add a custom certificates file
+	CertificateFilePath string `mapstructure:"certificate_file_path"`
+	// How many times should we retry imds v2
+	IMDSRetries int `mapstructure:"imds_retries"`
 }
 
 func CreateDefaultSessionConfig() AWSSessionSettings {

--- a/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil/refreshable_shared_credentials_provider.go
+++ b/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil/refreshable_shared_credentials_provider.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awsutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil"
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+const (
+	defaultExpiryWindow = time.Minute * 10
+)
+
+type RefreshableSharedCredentialsProvider struct {
+	credentials.Expiry
+	sharedCredentialsProvider *credentials.SharedCredentialsProvider
+
+	// Retrival frequency, if the value is 15 minutes, the credentials will be retrieved every 15 minutes.
+	ExpiryWindow time.Duration
+}
+
+// Retrieve reads and extracts the shared credentials from the current
+// users home directory.
+func (p *RefreshableSharedCredentialsProvider) Retrieve() (credentials.Value, error) {
+
+	if p.ExpiryWindow == 0 {
+		p.ExpiryWindow = defaultExpiryWindow
+	}
+	p.SetExpiration(time.Now().Add(p.ExpiryWindow), 0)
+	creds, err := p.sharedCredentialsProvider.Retrieve()
+	creds.ProviderName = "RefreshableSharedCredentialsProvider"
+
+	return creds, err
+}

--- a/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil/shared_config.go
+++ b/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil/shared_config.go
@@ -1,0 +1,86 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awsutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil"
+
+import (
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
+
+const (
+	envAwsSdkLoadConfig = "AWS_SDK_LOAD_CONFIG"
+	// nolint:gosec
+	envAwsSharedCredentialsFile = "AWS_SHARED_CREDENTIALS_FILE"
+	envAwsSharedConfigFile      = "AWS_CONFIG_FILE"
+)
+
+// getFallbackSharedConfigFiles follows the same logic as the AWS SDK but takes a getUserHomeDir
+// function.
+func getFallbackSharedConfigFiles(userHomeDirProvider func() string) []string {
+	var sharedCredentialsFile, sharedConfigFile string
+	setFromEnvVal(&sharedCredentialsFile, envAwsSharedCredentialsFile)
+	setFromEnvVal(&sharedConfigFile, envAwsSharedConfigFile)
+	log.Println("sharedCredentialsFile: ", sharedCredentialsFile)
+	if sharedCredentialsFile == "" {
+		sharedCredentialsFile = defaultSharedCredentialsFile(userHomeDirProvider())
+	}
+	if sharedConfigFile == "" {
+		sharedConfigFile = defaultSharedConfig(userHomeDirProvider())
+	}
+	var cfgFiles []string
+	enableSharedConfig, _ := strconv.ParseBool(os.Getenv(envAwsSdkLoadConfig))
+	if enableSharedConfig {
+		cfgFiles = append(cfgFiles, sharedConfigFile)
+	}
+	return append(cfgFiles, sharedCredentialsFile)
+}
+
+func setFromEnvVal(dst *string, keys ...string) {
+	for _, k := range keys {
+		if v := os.Getenv(k); len(v) != 0 {
+			*dst = v
+			break
+		}
+	}
+}
+
+func defaultSharedCredentialsFile(dir string) string {
+	return filepath.Join(dir, ".aws", "credentials")
+}
+
+func defaultSharedConfig(dir string) string {
+	return filepath.Join(dir, ".aws", "config")
+}
+
+// backwardsCompatibleUserHomeDir provides the home directory based on
+// environment variables.
+//
+// Based on v1.44.106 of the AWS SDK.
+func backwardsCompatibleUserHomeDir() string {
+	home, _ := os.UserHomeDir()
+	return home
+}
+
+// currentUserHomeDir attempts to use the environment variables before falling
+// back on the current user's home directory.
+//
+// Based on v1.44.332 of the AWS SDK.
+func currentUserHomeDir() string {
+	var home string
+
+	home = backwardsCompatibleUserHomeDir()
+	if len(home) > 0 {
+		return home
+	}
+
+	currUser, _ := user.Current()
+	if currUser != nil {
+		home = currUser.HomeDir
+	}
+
+	return home
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -401,6 +401,9 @@ github.com/alecthomas/participle/v2/lexer
 # github.com/alecthomas/units v0.0.0-20240626203959-61d1e3462e30
 ## explicit; go 1.15
 github.com/alecthomas/units
+# github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws v0.0.0-20250116001040-07637c7e4577
+## explicit; go 1.20
+github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws
 # github.com/antchfx/xmlquery v1.4.2
 ## explicit; go 1.14
 github.com/antchfx/xmlquery
@@ -1419,8 +1422,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authext
 ## explicit; go 1.22.0
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage/internal/metadata
-# github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.115.0
-## explicit; go 1.22.0
+# github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.115.0 => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutil v0.0.0-20250116001040-07637c7e4577
+## explicit; go 1.22.4
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil
 # github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.115.0
 ## explicit; go 1.22.0


### PR DESCRIPTION
**Description:** 

Resolves an issue where the GameLift shared credentials file was not being refreshed by the EMF exporter.

**Link to tracking Issue:** https://github.com/orgs/rocketsciencegg/projects/14/views/3?pane=issue&itemId=95087870&issue=rocketsciencegg%7Caws-gamelift%7C240

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
